### PR TITLE
Make caos test work without any arguments from task folder

### DIFF
--- a/caos
+++ b/caos
@@ -1,1 +1,1 @@
-python3 caoslib/main.py "$@"
+python3 $(dirname "$0")/caoslib/main.py "$@"

--- a/caoslib/src/initialization.py
+++ b/caoslib/src/initialization.py
@@ -1,4 +1,4 @@
-from utils.constants import CONFIG_PATH, COOKIES_PATH, LINKS_PATH
+from utils.constants import FILES_PATH, CONFIG_PATH, COOKIES_PATH, LINKS_PATH
 
 import os
 import requests
@@ -9,8 +9,8 @@ from clint.textui import puts, colored, prompt
 
 
 def init():
-    if 'files' not in os.listdir(os.getcwd() + '/caoslib'):
-        os.mkdir(os.getcwd() + '/caoslib/files')
+    if not os.path.exists(FILES_PATH):
+        os.mkdir(FILES_PATH)
 
     open(CONFIG_PATH, 'a').close()
     open(COOKIES_PATH, 'a').close()

--- a/caoslib/src/test.py
+++ b/caoslib/src/test.py
@@ -4,6 +4,7 @@ from clint.textui import puts, colored, indent
 import os
 import tempfile
 
+
 def test(args):
     task_path = get_task(args)
     tests_path = os.path.join(task_path, 'tests')
@@ -41,11 +42,13 @@ def get_task_from_folder(folder):
         return None
     return os.path.join(CAOS_DIR, tokens[0], tokens[1])
 
+
 def get_task_from_args(args):
     grouped = args.grouped
     if '-c' not in grouped or '-t' not in grouped or len(grouped['-c']) == 0 or len(grouped['-t']) == 0:
         return None
     return os.path.join(CAOS_DIR, grouped['-c'][0], grouped['-t'][0])
+
 
 def get_task(args):
     task_path = get_task_from_args(args) or get_task_from_folder(os.getcwd())
@@ -54,12 +57,14 @@ def get_task(args):
         exit(0)
     return task_path
 
+
 def run_test(task_path, test, executable_path):
     input_path = os.path.join(task_path, 'tests', test + '.dat')
     output_path = os.path.join(task_path, 'tests', test + '.ans')
 
     if not os.path.exists(output_path):
-        puts(colored.yellow(f"No matching output for test {input_path}. {output_path} doesn't exits. Skip it."))
+        puts(colored.yellow(f"""No matching output for test {input_path}. \
+        {output_path} doesn't exits. Skip it."""))
         return
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/caoslib/src/test.py
+++ b/caoslib/src/test.py
@@ -2,11 +2,10 @@ from utils.constants import CAOS_DIR, COMPILATION_STRING
 
 from clint.textui import puts, colored, indent
 import os
-
+import tempfile
 
 def test(args):
-    (contest, task) = get_task_name(args)
-    task_path = os.path.join(CAOS_DIR, contest, task)
+    task_path = get_task(args)
     tests_path = os.path.join(task_path, 'tests')
 
     tests = []
@@ -16,56 +15,69 @@ def test(args):
         puts(colored.red(f"Path {tests_path} doesn't exist."))
         exit(0)
 
-    inputs = filter(lambda x: x[x.find('.') + 1:] == 'dat', tests)
-    inputs = list(map(lambda x: x[:x.find('.')], inputs))
-    if not inputs:
+    tests = filter(lambda x: os.path.splitext(x)[1] == '.dat', tests)
+    tests = list(map(lambda x: os.path.splitext(x)[0], tests))
+    if not tests:
         puts(colored.red(f"No tests found at {tests_path}"))
         exit(0)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        executable_path = os.path.join(temp_dir, 'a.out')
+        os.system(COMPILATION_STRING.format(os.path.join(task_path, 'main.c'), executable_path))
+        if not os.path.exists(executable_path):
+            puts(colored.red(f"Compilation error, aborted"))
+            exit(0)
 
-    if 'a.out' in os.listdir(os.getcwd()):
-        os.remove('a.out')
-    os.system(COMPILATION_STRING.format(os.path.join(task_path, 'main.c')))
-    if 'a.out' not in os.listdir(os.getcwd()):
-        puts(colored.red(f"Compilation error, aborted"))
-        exit(0)
-
-    for input in inputs:
-        if input + '.ans' not in tests:
-            puts(colored.yellow(f"No matching output for test {input}.dat. Skip it."))
-            continue
-
-        run_test(contest, task, input)
-
-    os.remove('temp')
-    os.remove('a.out')
+        for test in tests:
+            run_test(task_path, test, executable_path)
 
 
-def get_task_name(args):
+def get_task_from_folder(folder):
+    folder = os.path.abspath(folder)
+    caos_dir = os.path.abspath(CAOS_DIR)
+    if os.path.commonprefix([caos_dir, folder]) != caos_dir:
+        return None
+    tokens = os.path.relpath(folder, caos_dir).split(os.path.sep)
+    if len(tokens) < 2:
+        return None
+    return os.path.join(CAOS_DIR, tokens[0], tokens[1])
+
+def get_task_from_args(args):
     grouped = args.grouped
     if '-c' not in grouped or '-t' not in grouped or len(grouped['-c']) == 0 or len(grouped['-t']) == 0:
-        puts(colored.red("Provide both -c and -t flags for testing."))
+        return None
+    return os.path.join(CAOS_DIR, grouped['-c'][0], grouped['-t'][0])
+
+def get_task(args):
+    task_path = get_task_from_args(args) or get_task_from_folder(os.getcwd())
+    if not task_path:
+        puts(colored.red("Provide both -c and -t flags or switch to task directory for testing."))
         exit(0)
-    return (grouped['-c'][0], grouped['-t'][0])
+    return task_path
 
-
-def run_test(contest, task, test):
-    task_path = os.path.join(CAOS_DIR, contest, task)
+def run_test(task_path, test, executable_path):
     input_path = os.path.join(task_path, 'tests', test + '.dat')
     output_path = os.path.join(task_path, 'tests', test + '.ans')
 
-    os.system('./a.out < {} > temp'.format(input_path))
+    if not os.path.exists(output_path):
+        puts(colored.yellow(f"No matching output for test {input_path}. {output_path} doesn't exits. Skip it."))
+        return
 
-    with open(output_path, 'r') as output_file:
-        with open('temp', 'r') as temp_file:
-            expected_lines = output_file.readlines()
-            resulting_lines = temp_file.readlines()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        result_path = os.path.join(temp_dir, 'res')
 
-            if expected_lines == resulting_lines:
-                puts(colored.green(f"Test {test}: OK!"))
-            else:
-                puts(colored.red(f"Test {test}: Failed!"))
-                find_diff(expected_lines, resulting_lines)
-                exit(0)
+        os.system('{} < {} > {}'.format(executable_path, input_path, result_path))
+
+        with open(output_path, 'r') as output_file:
+            with open(result_path, 'r') as temp_file:
+                expected_lines = output_file.readlines()
+                resulting_lines = temp_file.readlines()
+
+                if expected_lines == resulting_lines:
+                    puts(colored.green(f"Test {test}: OK!"))
+                else:
+                    puts(colored.red(f"Test {test}: Failed!"))
+                    find_diff(expected_lines, resulting_lines)
+                    exit(0)
 
 
 def find_diff(expected_lines, resulting_lines):

--- a/caoslib/src/test.py
+++ b/caoslib/src/test.py
@@ -63,8 +63,8 @@ def run_test(task_path, test, executable_path):
     output_path = os.path.join(task_path, 'tests', test + '.ans')
 
     if not os.path.exists(output_path):
-        puts(colored.yellow(f"""No matching output for test {input_path}. \
-        {output_path} doesn't exits. Skip it."""))
+        puts(colored.yellow(f"No matching output for test {input_path}. \
+        {output_path} doesn't exits. Skip it."))
         return
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/caoslib/src/test.py
+++ b/caoslib/src/test.py
@@ -64,7 +64,7 @@ def run_test(task_path, test, executable_path):
 
     if not os.path.exists(output_path):
         puts(colored.yellow(f"No matching output for test {input_path}. \
-        {output_path} doesn't exits. Skip it."))
+            {output_path} doesn't exits. Skip it."))
         return
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/caoslib/src/test.py
+++ b/caoslib/src/test.py
@@ -63,8 +63,8 @@ def run_test(task_path, test, executable_path):
     output_path = os.path.join(task_path, 'tests', test + '.ans')
 
     if not os.path.exists(output_path):
-        puts(colored.yellow(f"No matching output for test {input_path}. \
-            {output_path} doesn't exits. Skip it."))
+        puts(colored.yellow(f"No matching output for test {input_path}"))
+        puts(colored.yellow(f"{output_path} doesn't exits. Skip it."))
         return
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/caoslib/src/test.py
+++ b/caoslib/src/test.py
@@ -77,10 +77,17 @@ def run_test(task_path, test, executable_path):
                 else:
                     puts(colored.red(f"Test {test}: Failed!"))
                     find_diff(expected_lines, resulting_lines)
+                    saved_output_path = os.path.join(task_path, 'tests', test + '.res')
+                    os.rename(result_path, saved_output_path)
+                    puts(colored.red(f"Resulting output saved to '{saved_output_path}' file."))
                     exit(0)
 
 
 def find_diff(expected_lines, resulting_lines):
+    if (len(expected_lines) != len(resulting_lines)):
+        print("Expected and resulting files have different number of lines")
+        return
+
     count = 0
     for (line, (expected, resulting)) in enumerate(zip(expected_lines, resulting_lines)):
         if expected != resulting:
@@ -91,5 +98,3 @@ def find_diff(expected_lines, resulting_lines):
 
         if count == 10:
             break
-
-    puts(colored.red(f"Resulting output saved to the 'temp' file."))

--- a/caoslib/utils/constants.py
+++ b/caoslib/utils/constants.py
@@ -1,10 +1,12 @@
 import os
 
 # important paths
-CONFIG_PATH = os.getcwd() + '/caoslib/files/config.ini'
-COOKIES_PATH = os.getcwd() + '/caoslib/files/cookies.owo'
-LINKS_PATH = os.getcwd() + '/caoslib/files/links.json'
-CAOS_DIR = os.getenv('HOME') + '/programming/caos'
+CAOSLIB_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir)
+FILES_PATH = os.path.join(CAOSLIB_DIR, 'files')
+CONFIG_PATH = os.path.join(FILES_PATH, 'config.ini')
+COOKIES_PATH = os.path.join(FILES_PATH, 'cookies.owo')
+LINKS_PATH = os.path.join(FILES_PATH, 'links.json')
+CAOS_DIR = os.path.join(os.getenv('HOME'), 'programming', 'caos')
 
 # links
 SETTINGS = 'Settings'
@@ -19,4 +21,4 @@ OK = 'OK'
 REVIEW = 'Pending review'
 NOT_SUBMITTED = 'Not submitted'
 
-COMPILATION_STRING = "gcc -O2 -Wall -Werror -Wno-unused-result -std=gnu11 -lm -fsanitize=address -fsanitize=leak -fsanitize=undefined -fno-sanitize-recover {}"
+COMPILATION_STRING = "gcc -O2 -Wall -Werror -Wno-unused-result -std=gnu11 -lm -fsanitize=address -fsanitize=leak -fsanitize=undefined -fno-sanitize-recover {} -o {}"


### PR DESCRIPTION
Fix work with paths. In caos test extract task and contest from cwd. Do not leave trash in directory after test failure 